### PR TITLE
Correctly write export file for multi-buildpack compatibility

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,7 @@ indent() {
   sed -u 's/^/       /'
 }
 
+BP_DIR=$(dirname $(readlink -f $0))
 BUILD_DIR=$1
 VENDOR_DIR="vendor"
 FFMPEG_VERSION=${FFMPEG_VERSION:-"2.8.6"}
@@ -29,3 +30,6 @@ echo "exporting PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/ffmpeg.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="/app/vendor/ffmpeg/bin:$PATH"' >> $PROFILE_PATH
+
+# For multi-buildpack support, add an export file
+echo 'export PATH="$BUILD_DIR/vendor/ffmpeg/bin:$PATH"' >> $BP_DIR/export


### PR DESCRIPTION
Related to: https://github.com/Scalingo/multi-buildpack/blob/master/bin/compile#L64-L66
and: https://app.intercom.com/a/apps/w4oogu7s/inbox/inbox/all/conversations/12375700007974