### PR TITLE
docs(readme): this buildpack is now deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-Buildpack for ffmpeg
-====================
+# [DEPRECATED] Buildpack: ffmpeg
 
-This project is a Scalingo [buildpack](http://doc.scalingo.com/buildpacks) for using [ffmpeg](http://www.ffmpeg.org/) in your project.
+The ffmpeg buildpack is deprecated. This is replaced with the use of the [APT buildpack](https://github.com/Scalingo/apt-buildpack/). Please refer to the [Scalingo documentation](https://doc.scalingo.com/platform/deployment/buildpacks/ffmpeg) for a more future proof way to install ffmpeg or ffprobe.
+
+This project is a Scalingo [buildpack](http://doc.scalingo.com/buildpacks) for using [ffmpeg](https://www.ffmpeg.org) in your project.
 
 It doesn't do anything else, you have to use it alongside another buildpack thanks to the [multi-buildpack](https://github.com/Scalingo/multi-buildpack).
 
@@ -11,19 +12,19 @@ Usage
 -----
 
 ## Setup the multi-buildpack
-To use this buildpack, you should prepare .buildpacks file that contains this buildpack url and your real buildpack url.  
+To use this buildpack, you should prepare .buildpacks file that contains this buildpack url and your real buildpack url.
 
 ```
 $ cat .buildpacks
 https://github.com/Scalingo/ffmpeg-buildpack.git
-https://github.com/Scalingo/go-buildpack.git 
+https://github.com/Scalingo/go-buildpack.git
 ```
 
 The first buildpack will install FFmpeg, the second will handle the deployment of your go application. For any other technology,
-go to [http://doc.scalingo.com/buildpacks/](http://doc.scalingo.com/buildpacks/)
+go to [Scalingo documentation](https://doc.scalingo.com/platform/deployment/buildpacks/intro).
 
 ## Setup your application configuration
-    
+
 ```
 $ scalingo env-set BUILDPACK_URL=https://github.com/Scalingo/multi-buildpack.git
 $ git push scalingo master


### PR DESCRIPTION
And can you archive the repository?

Fix https://github.com/Scalingo/ffmpeg-buildpack/issues/4